### PR TITLE
hotfix(ipdb): temporary fix memory leak

### DIFF
--- a/ipip/ipip.c
+++ b/ipip/ipip.c
@@ -27,7 +27,11 @@ ipdb_meta_data *parse_meta_data(const char *meta_json) {
     json_error_t error;
 
     root = json_loads(meta_json, 0, &error);
-
+    if(!root) {
+        fprintf(stderr, "error: %s\n", error.text);
+        json_decref(root);
+        return 1;
+    }
     json_t *node_count, *total_size, *build, *ip_version, *fields, *lang;
     double node_count_number, total_size_number, build_number, ip_version_number;
     const char *fields_array, *language_object;

--- a/ui/ipip.c
+++ b/ui/ipip.c
@@ -8,18 +8,29 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+char *defaultDB = "/usr/local/share/17monipdb.ipdb";
+ipdb_reader *reader;
+int exists = 0;
+int load_reader() {
+    int err = ipdb_reader_new(defaultDB, &reader);
+    if (err) {
+        // fail to init db, return empty
+        return err;
+    }
+    exists = 1;
+    return 0;
+}
 const char *ipip_get_location(struct mtr_ctl *ctl, const char *ip) {
     // result buffer
     static char buf[256];
     buf[0] = '\0';
 
     // init ipdb reader
-    char * defaultDB = "/usr/local/share/17monipdb.ipdb";
-    ipdb_reader *reader;
-    int err = ipdb_reader_new(defaultDB, &reader);
-    if (err) {
-        // fail to init db, return empty
-        return buf;
+    if (!exists) {
+        int err = load_reader();
+        if (err) {
+            return buf;
+        }
     }
 
     const char *lang[2];


### PR DESCRIPTION
add a error log while meta_json loads failed (Big Integer)
move *reader to global and add a flag to avoid refreshing *reader what make a memory leak